### PR TITLE
Change checkstyle rule

### DIFF
--- a/config/quality/checkstyle/checkstyle.xml
+++ b/config/quality/checkstyle/checkstyle.xml
@@ -130,7 +130,7 @@
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MethodName">
-            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
             <message key="name.invalidPattern"
                      value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>


### PR DESCRIPTION
## What
This changes a checkstyle rule used to check if a method name is right.

## Why
We want to have names like "iPressSubmit()", but this was not accepted before. After this change it will be accepted.

## How
You can run checkstyle to test if the error is not given anymore.
