### PR TITLE
Change minimum SDK version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "25.0.3"
     defaultConfig {
         applicationId "com.nervousfish.nervousfish"
-        minSdkVersion 22
+        minSdkVersion 19
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
- Relevant Issues: n/a
- Related Pull Requests: n/a

* * *

## What
Update the minimum SDK version required for the application.

## Why
The goal is to reach more people. After some research it turned out that (in contrast to my original believes) there are still quite a few phones out that that still run Android 4.4 KitKat (which uses SDK 19 as opposed to 21). The number of Android phones is ~19% while Lollipop (5.0 and 5.1 combined) is ~32% and Marshmallow (6.0) ~31%. [Source](Source: https://developer.android.com/about/dashboards/index.html)

## How
n/a

## Notes
To be sure this work you could try to build the app locally.