### PR TITLE
Add Coveralls support to the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: android
 jdk: oraclejdk8
+
+# Android details
 android:
   components:
     - tools
@@ -22,12 +24,16 @@ android:
     - sys-img-armeabi-v7a-android-22
     - sys-img-armeabi-v7a-android-25
 
-# Emulator Management: Create, Start and Wait
+# Start emulators
 before_script:
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+
+# Upload test report to coveralls
+after_success:
+  - gradle jacocoTestReport coveralls
 
 # Manage caching
 before_cache:
@@ -39,6 +45,7 @@ cache:
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
 
+# Manage notifications
 notifications:
   email:
     on_success: never

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NervousFish
 [![Build Status](https://travis-ci.org/ericcornelissen/NervousFish.svg?branch=develop)](https://travis-ci.org/ericcornelissen/NervousFish)
+[![Coverage Status](https://coveralls.io/repos/github/ericcornelissen/NervousFish/badge.svg?branch=master)](https://coveralls.io/github/ericcornelissen/NervousFish?branch=master)
 
 An app for your :iphone: to exchange public-keys in a secure manner.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'jacoco'
+apply plugin: 'coveralls'
 apply from: '../config/quality.gradle'
 
 android {
@@ -52,9 +53,9 @@ task jacocoTestReport(type: JacocoReport, dependsOn: "connectedDebugAndroidTest"
     group = "Reporting"
     description = "Generate Jacoco coverage reports after running tests."
     reports {
-        xml.enabled = false
         csv.enabled false
-        html.destination "${buildDir}/jacocoHtml"
+        html.enabled true
+        xml.enabled true
     }
     classDirectories = fileTree(
             dir: './build/intermediates/classes/debug',

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:0.3.0'
     }
 }
 


### PR DESCRIPTION
- Relevant Issues: n/a
- Related Pull Requests: n/a

* * *

## What
This PR adds support for [Coveralls](https://coveralls.io/) to the repository. It will also add a Coveralls badge to the README 😎

## Why
This gives us and people who visit the repository an overview of the code coverage of the project.

## How
The coverage report generated by Jacoco (available since #48) will be uploaded to Coveralls after the build on Travis-CI was successful.

## Alternative implementation
There are a few alternatives to Coveralls out there, e.g. [Codecov](https://codecov.io/), but I have some experience with Coveralls and like it 🙂 

## Notes
n/a
