### PR TITLE
Add a powermock alternative

### DIFF
--- a/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
@@ -1,0 +1,87 @@
+package com.nervousfish.nervousfish;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * The superclass of all tests
+ */
+public abstract class BaseTest {
+
+    /**
+     * Creates a new instance of a class that has an inaccessible constructor (eg private)
+     *
+     * @param clazz The class that should be instantiated
+     * @return A new instance of clazz
+     */
+    public Object accessConstructor(final Class<?> clazz) {
+        try {
+            final Constructor<?> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+        throw new RuntimeException();
+    }
+
+    /**
+     * Executes an inaccessible method on an object (eg private method)
+     *
+     * @param object      The object owning the method
+     * @param method_name The name of the method
+     * @param args        The arguments of the method
+     * @return The result of the method
+     */
+    public Object accessMethod(final Object object, final String method_name, final Object... args) {
+        try {
+            final Method[] methods = object.getClass().getMethods();
+            for (Method method : methods) {
+                if (method.getName().equals(method_name)) {
+                    method.setAccessible(true);
+                    return method.invoke(object, args);
+                }
+            }
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        throw new RuntimeException();
+    }
+
+    /**
+     * Sets the value of an inaccessible field on an object (eg private field)
+     *
+     * @param object     The object owning the method
+     * @param field_name The name of the field
+     * @param value      The new value of the field
+     */
+    public void setField(final Object object, final String field_name, final Object value) {
+        try {
+            final Field field = object.getClass().getField(field_name);
+            field.setAccessible(true);
+            field.set(object, value);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        throw new RuntimeException();
+    }
+
+    /**
+     * Gets the value of an inaccessible field on an object (eg private field)
+     *
+     * @param object     The object owning the method
+     * @param field_name The name of the field
+     */
+    public Object getField(final Object object, final String field_name) {
+        try {
+            final Field field = object.getClass().getField(field_name);
+            field.setAccessible(true);
+            return field.get(object);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        throw new RuntimeException();
+    }
+}

--- a/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
@@ -6,20 +6,20 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
- * The superclass of all tests
+ * Provides Powermock-functionality to tests.
  */
 public final class BaseTest {
 
     /**
-     * Prevents instantiation
+     * Simple constructor for the BaseTest class
      */
     private BaseTest() {
         // Prevents instantiation
     }
 
     /**
-     * Creates a new instance of a class that has an inaccessible constructor (eg private)
-     * Note that there should be a single constructor in the class
+     * Creates a new instance of a class that has an inaccessible constructor (e.g. private).
+     * Note that there should be a single constructor in the class.
      *
      * @param clazz The class that should be instantiated
      * @param args  The arguments that should be passed to the constructor
@@ -40,7 +40,7 @@ public final class BaseTest {
     }
 
     /**
-     * Executes an inaccessible method on an object (eg private method)
+     * Executes an inaccessible method on an object (e.g. private method).
      *
      * @param object      The object owning the method
      * @param method_name The name of the method
@@ -63,7 +63,7 @@ public final class BaseTest {
     }
 
     /**
-     * Sets the value of an inaccessible field on an object (eg private field)
+     * Sets the value of an inaccessible field on an object (e.g. private field).
      *
      * @param object     The object owning the method
      * @param field_name The name of the field
@@ -81,7 +81,7 @@ public final class BaseTest {
     }
 
     /**
-     * Gets the value of an inaccessible field on an object (eg private field)
+     * Gets the value of an inaccessible field on an object (e.g. private field).
      *
      * @param object     The object owning the method
      * @param field_name The name of the field

--- a/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
@@ -12,16 +12,21 @@ public abstract class BaseTest {
 
     /**
      * Creates a new instance of a class that has an inaccessible constructor (eg private)
+     * Note that there should be a single constructor in the class
      *
      * @param clazz The class that should be instantiated
+     * @param args  The arguments that should be passed to the constructor
      * @return A new instance of clazz
      */
-    public Object accessConstructor(final Class<?> clazz) {
+    protected Object accessConstructor(final Class<?> clazz, final Object... args) {
         try {
-            final Constructor<?> constructor = clazz.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            return constructor.newInstance();
-        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            final Constructor<?>[] constructors = clazz.getDeclaredConstructors();
+            // Assuming a single constructor
+            for (Constructor<?> constructor : constructors) {
+                constructor.setAccessible(true);
+                return constructor.newInstance(args);
+            }
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         }
         throw new RuntimeException();
@@ -35,9 +40,9 @@ public abstract class BaseTest {
      * @param args        The arguments of the method
      * @return The result of the method
      */
-    public Object accessMethod(final Object object, final String method_name, final Object... args) {
+    protected Object accessMethod(final Object object, final String method_name, final Object... args) {
         try {
-            final Method[] methods = object.getClass().getMethods();
+            final Method[] methods = object.getClass().getDeclaredMethods();
             for (Method method : methods) {
                 if (method.getName().equals(method_name)) {
                     method.setAccessible(true);
@@ -57,9 +62,9 @@ public abstract class BaseTest {
      * @param field_name The name of the field
      * @param value      The new value of the field
      */
-    public void setField(final Object object, final String field_name, final Object value) {
+    protected void setField(final Object object, final String field_name, final Object value) {
         try {
-            final Field field = object.getClass().getField(field_name);
+            final Field field = object.getClass().getDeclaredField(field_name);
             field.setAccessible(true);
             field.set(object, value);
         } catch (IllegalAccessException | NoSuchFieldException e) {
@@ -74,9 +79,9 @@ public abstract class BaseTest {
      * @param object     The object owning the method
      * @param field_name The name of the field
      */
-    public Object getField(final Object object, final String field_name) {
+    protected Object getField(final Object object, final String field_name) {
         try {
-            final Field field = object.getClass().getField(field_name);
+            final Field field = object.getClass().getDeclaredField(field_name);
             field.setAccessible(true);
             return field.get(object);
         } catch (IllegalAccessException | NoSuchFieldException e) {

--- a/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/BaseTest.java
@@ -8,7 +8,14 @@ import java.lang.reflect.Method;
 /**
  * The superclass of all tests
  */
-public abstract class BaseTest {
+public final class BaseTest {
+
+    /**
+     * Prevents instantiation
+     */
+    private BaseTest() {
+        // Prevents instantiation
+    }
 
     /**
      * Creates a new instance of a class that has an inaccessible constructor (eg private)
@@ -18,7 +25,7 @@ public abstract class BaseTest {
      * @param args  The arguments that should be passed to the constructor
      * @return A new instance of clazz
      */
-    protected Object accessConstructor(final Class<?> clazz, final Object... args) {
+    protected static Object accessConstructor(final Class<?> clazz, final Object... args) {
         try {
             final Constructor<?>[] constructors = clazz.getDeclaredConstructors();
             // Assuming a single constructor
@@ -40,7 +47,7 @@ public abstract class BaseTest {
      * @param args        The arguments of the method
      * @return The result of the method
      */
-    protected Object accessMethod(final Object object, final String method_name, final Object... args) {
+    protected static Object accessMethod(final Object object, final String method_name, final Object... args) {
         try {
             final Method[] methods = object.getClass().getDeclaredMethods();
             for (Method method : methods) {
@@ -62,7 +69,7 @@ public abstract class BaseTest {
      * @param field_name The name of the field
      * @param value      The new value of the field
      */
-    protected void setField(final Object object, final String field_name, final Object value) {
+    protected static void setField(final Object object, final String field_name, final Object value) {
         try {
             final Field field = object.getClass().getDeclaredField(field_name);
             field.setAccessible(true);
@@ -79,7 +86,7 @@ public abstract class BaseTest {
      * @param object     The object owning the method
      * @param field_name The name of the field
      */
-    protected Object getField(final Object object, final String field_name) {
+    protected static Object getField(final Object object, final String field_name) {
         try {
             final Field field = object.getClass().getDeclaredField(field_name);
             field.setAccessible(true);

--- a/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+import static com.nervousfish.nervousfish.BaseTest.accessConstructor;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -19,7 +20,7 @@ import static org.mockito.Mockito.when;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 @SuppressWarnings("PMD")
-public class ExampleUnitTest extends BaseTest {
+public class ExampleUnitTest {
     ISample sample = mock(ISample.class);
 
     @Test

--- a/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
@@ -1,6 +1,11 @@
 package com.nervousfish.nervousfish;
 
+import com.nervousfish.nervousfish.modules.constants.Constants;
+
 import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -13,9 +18,18 @@ import static org.mockito.Mockito.when;
  */
 @SuppressWarnings("PMD")
 public class ExampleUnitTest {
+    ISample sample = mock(ISample.class);
+
     @Test
     public void addition_isCorrect() throws Exception {
         assertEquals(4, 2 + 2);
+    }
+
+    @Test
+    public void bar() {
+        when(sample.foo()).thenReturn(5);
+        assertEquals(new SampleClass(sample).get(), 5);
+        Constants constants = (Constants) accessInstance(Constants.class);
     }
 
     private interface ISample {
@@ -24,6 +38,7 @@ public class ExampleUnitTest {
 
     private class SampleClass {
         private final int tmp;
+
         private SampleClass(ISample sample) {
             tmp = sample.foo();
         }
@@ -31,13 +46,5 @@ public class ExampleUnitTest {
         private int get() {
             return tmp;
         }
-    }
-
-    ISample sample = mock(ISample.class);
-
-    @Test
-    public void bar() {
-        when(sample.foo()).thenReturn(5);
-        assertEquals(new SampleClass(sample).get(), 5);
     }
 }

--- a/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
@@ -1,6 +1,8 @@
 package com.nervousfish.nervousfish;
 
 import com.nervousfish.nervousfish.modules.constants.Constants;
+import com.nervousfish.nervousfish.service_locator.IServiceLocator;
+import com.nervousfish.nervousfish.service_locator.IServiceLocatorCreator;
 
 import org.junit.Test;
 
@@ -17,7 +19,7 @@ import static org.mockito.Mockito.when;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 @SuppressWarnings("PMD")
-public class ExampleUnitTest {
+public class ExampleUnitTest extends BaseTest {
     ISample sample = mock(ISample.class);
 
     @Test
@@ -29,7 +31,12 @@ public class ExampleUnitTest {
     public void bar() {
         when(sample.foo()).thenReturn(5);
         assertEquals(new SampleClass(sample).get(), 5);
-        Constants constants = (Constants) accessInstance(Constants.class);
+        Constants constants = (Constants) accessConstructor(Constants.class, new IServiceLocatorCreator() {
+            @Override
+            public IServiceLocator getServiceLocator() {
+                return null;
+            }
+        });
     }
 
     private interface ISample {

--- a/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/ExampleUnitTest.java
@@ -31,12 +31,7 @@ public class ExampleUnitTest extends BaseTest {
     public void bar() {
         when(sample.foo()).thenReturn(5);
         assertEquals(new SampleClass(sample).get(), 5);
-        Constants constants = (Constants) accessConstructor(Constants.class, new IServiceLocatorCreator() {
-            @Override
-            public IServiceLocator getServiceLocator() {
-                return null;
-            }
-        });
+        Constants constants = (Constants) accessConstructor(Constants.class, mock(IServiceLocatorCreator.class));
     }
 
     private interface ISample {


### PR DESCRIPTION
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
This pull request adds the new class BaseTest to the repository that should be extended by all test classes.

## Why
This PR is needed because everything is encapsulated as much as possible, while the tests do need access even to the strongly encapsulated classes.

## How
The new class BaseTest uses reflection to make it easy for the programmer to invoke private constructors / methods and access private fields.

## Alternative implementation
I have tried Powermock by using electro, but I couldn't get it working. I suspect it's because we're compiling using the most recent Android build tools.

## Notes
-
