### PR TITLE
Update key to JSON serialization

### DIFF
--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
@@ -1,6 +1,5 @@
 package com.nervousfish.nervousfish.data_objects;
 
-import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
@@ -27,6 +27,6 @@ public interface IKey {
     /**
      * Write the key to a {@link JsonWriter}.
      */
-    void writeJSON(final JsonWriter writer) throws IOException;
+    void toJSON(final JsonWriter writer) throws IOException;
 
 }

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
@@ -1,5 +1,9 @@
 package com.nervousfish.nervousfish.data_objects;
 
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
 /**
  * The interface for the standard Java representation of a (public/private) key.
  */
@@ -15,8 +19,13 @@ public interface IKey {
     /**
      * Get a string representation of the key type.
      *
-     * @return The type.
+     * @return The key type.
      */
     String getType();
+
+    /**
+     * Write the key to a {@link JsonWriter}.
+     */
+    void writeJSON(final JsonWriter writer) throws IOException;
 
 }

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/IKey.java
@@ -1,5 +1,6 @@
 package com.nervousfish.nervousfish.data_objects;
 
+import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
@@ -71,7 +71,7 @@ public final class RSAKey implements IKey {
      * {@inheritDoc}
      */
     @Override
-    public void writeJSON(final JsonWriter writer) throws IOException {
+    public void toJSON(final JsonWriter writer) throws IOException {
         writer.name("modulus").value(this.modulus);
         writer.name("exponent").value(this.exponent);
     }

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
@@ -1,9 +1,12 @@
 package com.nervousfish.nervousfish.data_objects;
 
+import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.nervousfish.nervousfish.ConstantKeywords;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * RSA variant of {@link IKey}.
@@ -27,6 +30,28 @@ public final class RSAKey implements IKey {
     }
 
     /**
+     * Create a new RSAKey given a {@link JsonReader}.
+     *
+     * @param reader The {@link JsonReader} to read with.
+     * @return An {@link IKey} representing the JSON key.
+     * @throws IOException When the {@link JsonReader} throws an {@link IOException}.
+     */
+    static public IKey fromJSON(final JsonReader reader) throws IOException {
+        final Map<String, String> map = new ConcurrentHashMap<>();
+        reader.beginObject();
+        while (reader.hasNext()) {
+            final String name = reader.nextName();
+            final String value = reader.nextString();
+            map.put(name, value);
+        }
+        reader.endObject();
+
+        final String modulus = map.get("modules");
+        final String exponent = map.get("exponent");
+        return new RSAKey(modulus, exponent);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -47,12 +72,8 @@ public final class RSAKey implements IKey {
      */
     @Override
     public void writeJSON(final JsonWriter writer) throws IOException {
-        writer.name("_type");
-        writer.value("RSA");
-        writer.name("modulus");
-        writer.value(this.modulus);
-        writer.name("exponent");
-        writer.value(this.exponent);
+        writer.name("modulus").value(this.modulus);
+        writer.name("exponent").value(this.exponent);
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
@@ -1,6 +1,9 @@
 package com.nervousfish.nervousfish.data_objects;
 
+import com.google.gson.stream.JsonWriter;
 import com.nervousfish.nervousfish.ConstantKeywords;
+
+import java.io.IOException;
 
 /**
  * RSA variant of {@link IKey}.
@@ -37,6 +40,19 @@ public final class RSAKey implements IKey {
     @Override
     public String getType() {
         return RSAKey.TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeJSON(final JsonWriter writer) throws IOException {
+        writer.name("_type");
+        writer.value("RSA");
+        writer.name("modulus");
+        writer.value(this.modulus);
+        writer.name("exponent");
+        writer.value(this.exponent);
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
@@ -26,7 +26,7 @@ public final class SimpleKey implements IKey {
     }
 
     /**
-     * Create a new RSAKey given a {@link JsonReader}.
+     * Create a new SimpleKey given a {@link JsonReader}.
      *
      * @param reader The {@link JsonReader} to read with.
      * @return An {@link IKey} representing the JSON key.
@@ -58,7 +58,7 @@ public final class SimpleKey implements IKey {
      * {@inheritDoc}
      */
     @Override
-    public void writeJSON(final JsonWriter writer) throws IOException {
+    public void toJSON(final JsonWriter writer) throws IOException {
         writer.name("key").value(this.key);
     }
 

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
@@ -4,8 +4,6 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Simple variant of {@link IKey}. This is an example implementation of the {@link IKey} interface.

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
@@ -1,5 +1,9 @@
 package com.nervousfish.nervousfish.data_objects;
 
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
 /**
  * Simple variant of {@link IKey}. This is an example implementation of the {@link IKey} interface.
  */
@@ -32,6 +36,17 @@ public final class SimpleKey implements IKey {
     @Override
     public String getType() {
         return SimpleKey.TYPE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeJSON(final JsonWriter writer) throws IOException {
+        writer.name("_type");
+        writer.value("simple");
+        writer.name("key");
+        writer.value(this.key);
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
@@ -1,8 +1,11 @@
 package com.nervousfish.nervousfish.data_objects;
 
+import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Simple variant of {@link IKey}. This is an example implementation of the {@link IKey} interface.
@@ -20,6 +23,19 @@ public final class SimpleKey implements IKey {
      */
     public SimpleKey(final String key) {
         this.key = key;
+    }
+
+    /**
+     * Create a new RSAKey given a {@link JsonReader}.
+     *
+     * @param reader The {@link JsonReader} to read with.
+     * @return An {@link IKey} representing the JSON key.
+     * @throws IOException When the {@link JsonReader} throws an {@link IOException}.
+     */
+    static public IKey fromJSON(final JsonReader reader) throws IOException {
+        reader.nextName();
+        final String key = reader.nextString();
+        return new SimpleKey(key);
     }
 
     /**
@@ -43,10 +59,7 @@ public final class SimpleKey implements IKey {
      */
     @Override
     public void writeJSON(final JsonWriter writer) throws IOException {
-        writer.name("_type");
-        writer.value("simple");
-        writer.name("key");
-        writer.value(this.key);
+        writer.name("key").value(this.key);
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
@@ -32,30 +32,7 @@ final class GsonKeyAdapter extends TypeAdapter<IKey> {
     @Override
     public void write(final JsonWriter writer, final IKey key) throws IOException {
         writer.beginObject();
-        switch (key.getType()) {
-            case ConstantKeywords.RSA_KEY:
-                writer.name(GsonKeyAdapter.KEY_TYPE_FIELD);
-                writer.value("RSA");
-
-                final String keyValue = key.getKey();
-                final String[] keyValues = keyValue.split(" ");
-                writer.name("modulus");
-                writer.value(keyValues[0]);
-                writer.name("exponent");
-                writer.value(keyValues[1]);
-
-                break;
-            case "simple":
-                writer.name(GsonKeyAdapter.KEY_TYPE_FIELD);
-                writer.value("simple");
-
-                writer.name("key");
-                writer.value(key.getKey());
-
-                break;
-            default:
-                throw new IOException("Could not write key");
-        }
+        key.writeJSON(writer);
         writer.endObject();
     }
 

--- a/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
@@ -9,8 +9,6 @@ import com.nervousfish.nervousfish.data_objects.RSAKey;
 import com.nervousfish.nervousfish.data_objects.SimpleKey;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Adaptor for the {@link IKey} interface for the GSON library.
@@ -39,7 +37,7 @@ final class GsonKeyAdapter extends TypeAdapter<IKey> {
 
         // Then write the rest of the key
         writer.beginObject();
-        key.writeJSON(writer);
+        key.toJSON(writer);
         writer.endObject();
 
         writer.endArray();

--- a/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
@@ -15,8 +15,6 @@ import java.io.IOException;
  */
 final class GsonKeyAdapter extends TypeAdapter<IKey> {
 
-    private final static String KEY_TYPE_FIELD = "_type";
-
     /**
      * Constructor for the {@code GsonKeyAdapter} class.
      */
@@ -47,12 +45,13 @@ final class GsonKeyAdapter extends TypeAdapter<IKey> {
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("PMD.AvoidFinalLocalVariable") // final IKey key is actually useful here
     public IKey read(final JsonReader reader) throws IOException {
         reader.beginArray();
         final String type = reader.nextString();
         reader.beginObject();
 
-        IKey key;
+        final IKey key;
         switch (type) {
             case ConstantKeywords.RSA_KEY:
                 key = RSAKey.fromJSON(reader);

--- a/app/src/test/java/com/nervousfish/nervousfish/modules/database/GsonDatabaseAdapterTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/modules/database/GsonDatabaseAdapterTest.java
@@ -66,7 +66,7 @@ public class GsonDatabaseAdapterTest {
         Contact contact = new Contact("Zoidberg", key);
 
         database.addContact(contact);
-        assertEquals("[{\"name\":\"Zoidberg\",\"publicKey\":{\"_type\":\"simple\",\"key\":\"key\"}}]\n", read(CONTACTS_PATH));
+        assertEquals("[{\"name\":\"Zoidberg\",\"publicKey\":[\"simple\",{\"key\":\"key\"}]}]\n", read(CONTACTS_PATH));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class GsonDatabaseAdapterTest {
         Contact contact = new Contact("Zoidberg", key);
 
         // Add the contact to remove from the database
-        write("[{\"name\":\"Zoidberg\",\"publicKey\":{\"_type\":\"simple\",\"key\":\"key\"}}]", CONTACTS_PATH);
+        write("[{\"name\":\"Zoidberg\",\"publicKey\":[\"simple\",{\"key\":\"key\"}]}]", CONTACTS_PATH);
 
         database.deleteContact(contact);
         assertEquals("[]\n", read(CONTACTS_PATH));
@@ -96,7 +96,7 @@ public class GsonDatabaseAdapterTest {
 
     @Test
     public void testGetAllContactsReturnsListOfAllContactsWith1Contact() throws IOException {
-        write("[{\"name\":\"Zoidberg\",\"publicKey\":{\"_type\":\"simple\",\"key\":\"key\"}}]", CONTACTS_PATH);
+        write("[{\"name\":\"Zoidberg\",\"publicKey\":[\"simple\",{\"key\":\"key\"}]}]", CONTACTS_PATH);
 
         IKey key = new SimpleKey("key");
         Contact contact = new Contact("Zoidberg", key);
@@ -109,8 +109,8 @@ public class GsonDatabaseAdapterTest {
 
     @Test
     public void testGetAllContactsReturnsListOfAllContactsWith2Contacts() throws IOException {
-        write("[{\"name\":\"Zoidberg\",\"publicKey\":{\"_type\":\"simple\",\"key\":\"ABABAB\"}}," +
-                "{\"name\":\"Fry\",\"publicKey\":{\"_type\":\"simple\",\"key\":\"BABABA\"}}]", CONTACTS_PATH);
+        write("[{\"name\":\"Zoidberg\",\"publicKey\":[\"simple\",{\"key\":\"ABABAB\"}]}," +
+                "{\"name\":\"Fry\",\"publicKey\":[\"simple\",{\"key\":\"BABABA\"}]}]", CONTACTS_PATH);
 
         IKey zoidbergsDey = new SimpleKey("ABABAB");
         Contact zoidberg = new Contact("Zoidberg", zoidbergsDey);
@@ -130,13 +130,13 @@ public class GsonDatabaseAdapterTest {
         Contact oldContact = new Contact("Zoidberg", keyA);
 
         // Add the contact to remove from the database
-        write("[{\"name\":\"Zoidberg\",\"publicKey\":{\"_type\":\"simple\",\"key\":\"keyA\"}}]", CONTACTS_PATH);
+        write("[{\"name\":\"Zoidberg\",\"publicKey\":[\"simple\",{\"key\":\"keyA\"}]}]", CONTACTS_PATH);
 
         IKey keyB = new SimpleKey("keyB");
         Contact newContact = new Contact("not Zoidberg", keyB);
 
         database.updateContact(oldContact, newContact);
-        assertEquals("[{\"name\":\"not Zoidberg\",\"publicKey\":{\"_type\":\"simple\",\"key\":\"keyB\"}}]\n", read(CONTACTS_PATH));
+        assertEquals("[{\"name\":\"not Zoidberg\",\"publicKey\":[\"simple\",{\"key\":\"keyB\"}]}]\n", read(CONTACTS_PATH));
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
- Relevant Issues: #67
- Related Pull Requests: -

* * *

## What
This PR changes two main things about the application. First and foremost it updates the way keys (instances of the `IKey` class) are serialized to JSON. As specified in #67 this is now done in the key class itself. Similarly the key class now also knows how to construct a key from given a `JsonReader`.

Besides that the JSON format for keys changed slightly to better accommodate the new writing style. To avoid having the rewrite (and possibly forget) the key type, this is still done in the `GsonKeyAdapter` class. This is now the first entry in an array representing the key. The second element is an object of key:value pairs constructed by the key class. So `{"_type":"simple","key":"key"}` changed to `["simple",{"key":"key"}]`.

## Why
This was done because the old implementation required a different class then the target class to know how to do something the target class should know itself.

## How
This was done by updating the `IKey` interface and moving the serialization code from the `GsonKeyAdapter` class to the classes implementing `IKey`.

## Alternative implementation
n/a

## Notes
I'm not quite sure about reading the keys yet (this is currently implemented using `static` methods on the classes implementing `IKey`), if anyone has a better suggestion be sure to let me know!
