### PR TITLE
Update Profile class to use KeyPair

### DIFF
--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/KeyPair.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/KeyPair.java
@@ -3,17 +3,16 @@ package com.nervousfish.nervousfish.data_objects;
 /**
  * KeyPair POJO which keeps a public and private key.
  */
-
 public final class KeyPair {
 
     private final IKey publicKey;
     private final IKey privateKey;
 
     /**
-     * Constructor for the KeyPair.
+     * The constructor for the {@link KeyPair}.
      *
-     * @param publicKey The publicKey of the KeyPair.
-     * @param privateKey The privateKey of the KeyPair.
+     * @param publicKey The public key.
+     * @param privateKey The private key.
      */
     public KeyPair(final IKey publicKey, final IKey privateKey) {
         this.publicKey = publicKey;
@@ -21,18 +20,18 @@ public final class KeyPair {
     }
 
     /**
-     * Returns the public key of this KeyPair.
+     * Returns the public key of the {@link KeyPair}.
      *
-     * @return the public key as IKey.
+     * @return the public {@link IKey}.
      */
     public IKey getPublicKey() {
         return this.publicKey;
     }
 
     /**
-     * Returns the private key of this KeyPair.
+     * Returns the private key of the {@link KeyPair}.
      *
-     * @return the private key as IKey.
+     * @return the private {@link IKey}.
      */
     public IKey getPrivateKey() {
         return this.privateKey;

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/Profile.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/Profile.java
@@ -6,41 +6,51 @@ package com.nervousfish.nervousfish.data_objects;
 public class Profile {
 
     private final String name;
-    private final IKey publicKey;
-    private final IKey privateKey;
+    private final KeyPair keyPair;
 
     /**
-     * A constructor for the {@link Profile} class.
+     * The constructor for the {@link Profile} class.
      *
-     * @param name - the name belonging to the Profile
-     * @param publicKey - the public key
-     * @param privateKey - the private key
+     * @param name the name belonging to the Profile
+     * @param keyPair the public/private key-pair
      */
-    public Profile(final String name, final IKey publicKey, final IKey privateKey) {
+    public Profile(final String name, final KeyPair keyPair) {
         this.name = name;
-        this.publicKey = publicKey;
-        this.privateKey = privateKey;
+        this.keyPair = keyPair;
     }
 
     /**
      * Get the name of the {@link Profile}.
+     *
+     * @return The name.
      */
     public String getName() {
         return this.name;
     }
 
     /**
-     * Get the public key of the {@link Profile}.
+     * Get the {@link KeyPair} of the {@link Profile}.
+     *
+     * @return The {@link KeyPair}.
+     */
+    public KeyPair getKeyPair() { return this.keyPair; }
+
+    /**
+     * Get the public {@link IKey} of the {@link Profile}.
+     *
+     * @return The public {@link IKey}.
      */
     public IKey getPublicKey() {
-        return this.publicKey;
+        return this.keyPair.getPublicKey();
     }
 
     /**
-     * Get the private key of the {@link Profile}.
+     * Get the private {@link IKey} of the {@link Profile}.
+     *
+     * @return The private {@link IKey}.
      */
     public IKey getPrivateKey() {
-        return this.privateKey;
+        return this.keyPair.getPrivateKey();
     }
 
     /**
@@ -54,8 +64,7 @@ public class Profile {
 
         final Profile that = (Profile) o;
         return this.name.equals(that.name)
-            && this.publicKey.equals(that.publicKey)
-            && this.privateKey.equals(that.privateKey);
+            && this.keyPair.equals(that.keyPair);
     }
 
     /**
@@ -63,7 +72,7 @@ public class Profile {
      */
     @Override
     public int hashCode() {
-        return this.name.hashCode() + this.publicKey.hashCode() + this.privateKey.hashCode();
+        return this.name.hashCode() + this.keyPair.hashCode();
     }
 
 }

--- a/app/src/test/java/com/nervousfish/nervousfish/data_objects/ProfileTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/data_objects/ProfileTest.java
@@ -11,71 +11,69 @@ import static org.mockito.Mockito.mock;
 
 public class ProfileTest {
 
-    private IKey publicKey;
-    private IKey privateKey;
+    private KeyPair keyPair;
 
     @Before
     public void setup() {
-        this.publicKey = mock(IKey.class);
-        this.privateKey = mock(IKey.class);
+        this.keyPair = new KeyPair(mock(IKey.class), mock(IKey.class));
     }
 
     @Test
     public void testCanBeInstantiatedWithArbitraryValues() {
-        Profile profile = new Profile("name", this.publicKey, this.privateKey);
+        Profile profile = new Profile("name", this.keyPair);
         assertNotNull(profile);
     }
 
     @Test
     public void testGetNameReturnsTheName() {
-        Profile profileA = new Profile("foo", this.publicKey, this.privateKey);
+        Profile profileA = new Profile("foo", this.keyPair);
         assertEquals("foo", profileA.getName());
 
-        Profile profileB = new Profile("bar", this.publicKey, this.privateKey);
+        Profile profileB = new Profile("bar", this.keyPair);
         assertEquals("bar", profileB.getName());
     }
 
     @Test
     public void testGetPublicKeyReturnsThePublicKey() {
-        Profile profile = new Profile("foo", this.publicKey, this.privateKey);
-        assertEquals(this.publicKey, profile.getPublicKey());
+        Profile profile = new Profile("foo", this.keyPair);
+        assertEquals(this.keyPair.getPublicKey(), profile.getPublicKey());
     }
 
     @Test
     public void testGetPrivateKeyReturnsThePrivateKey() {
-        Profile profile = new Profile("foo", this.publicKey, this.privateKey);
-        assertEquals(this.privateKey, profile.getPrivateKey());
+        Profile profile = new Profile("foo", this.keyPair);
+        assertEquals(this.keyPair.getPrivateKey(), profile.getPrivateKey());
     }
 
     @Test
     public void testEqualsWorksWithNull() {
-        Profile profile = new Profile("foo", this.publicKey, this.privateKey);
+        Profile profile = new Profile("foo", this.keyPair);
         assertFalse(profile.equals(null));
     }
 
     @Test
     public void testEqualsWorksWithArbitraryObject() {
-        Profile profile = new Profile("foo", this.publicKey, this.privateKey);
+        Profile profile = new Profile("foo", this.keyPair);
         assertFalse(profile.equals("foobar"));
     }
 
     @Test
     public void testEqualsReturnsFalseForUnequalKeys() {
-        Profile profileA = new Profile("Eric", this.publicKey, this.privateKey);
-        Profile profileB = new Profile("Kilian", this.publicKey, this.privateKey);
+        Profile profileA = new Profile("Eric", this.keyPair);
+        Profile profileB = new Profile("Kilian", this.keyPair);
         assertFalse(profileA.equals(profileB));
     }
 
     @Test
     public void testEqualsReturnsTrueForEqualKeys() {
-        Profile profileA = new Profile("Cornel", this.publicKey, this.privateKey);
-        Profile profileB = new Profile("Cornel", this.publicKey, this.privateKey);
+        Profile profileA = new Profile("Cornel", this.keyPair);
+        Profile profileB = new Profile("Cornel", this.keyPair);
         assertTrue(profileA.equals(profileB));
     }
 
     @Test
     public void testHashCodeNotNull() {
-        Profile profile = new Profile("Stas", this.publicKey, this.privateKey);
+        Profile profile = new Profile("Stas", this.keyPair);
         assertNotNull(profile.hashCode());
     }
 

--- a/app/src/test/java/com/nervousfish/nervousfish/modules/database/GsonDatabaseAdapterTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/modules/database/GsonDatabaseAdapterTest.java
@@ -1,5 +1,6 @@
 package com.nervousfish.nervousfish.modules.database;
 
+import com.nervousfish.nervousfish.data_objects.KeyPair;
 import com.nervousfish.nervousfish.data_objects.Profile;
 import com.nervousfish.nervousfish.data_objects.Contact;
 import com.nervousfish.nervousfish.data_objects.IKey;
@@ -160,7 +161,8 @@ public class GsonDatabaseAdapterTest {
     public void testAddProfile() throws IOException {
         IKey pubKey = new SimpleKey("PubKey");
         IKey privKey = new SimpleKey("privKey");
-        Profile newProfile = new Profile("CoolGuy", pubKey, privKey);
+        KeyPair keyPair = new KeyPair(pubKey, privKey);
+        Profile newProfile = new Profile("CoolGuy", keyPair);
         database.addProfile(newProfile);
 
         List<Profile> actual = database.getProfiles();
@@ -171,10 +173,11 @@ public class GsonDatabaseAdapterTest {
     public void testUpdateProfile() throws IOException {
         IKey pubKey = new SimpleKey("PubKey");
         IKey privKey = new SimpleKey("privKey");
-        Profile newProfile = new Profile("CoolGuy", pubKey, privKey);
+        KeyPair keyPair = new KeyPair(pubKey, privKey);
+        Profile newProfile = new Profile("CoolGuy", keyPair);
         database.addProfile(newProfile);
 
-        Profile newProfileUpdate = new Profile("OtherName", pubKey, privKey);
+        Profile newProfileUpdate = new Profile("OtherName", keyPair);
         database.updateProfile(newProfile, newProfileUpdate);
         List<Profile> actual = database.getProfiles();
 
@@ -187,7 +190,8 @@ public class GsonDatabaseAdapterTest {
     public void testDeleteProfile() throws IOException {
         IKey pubKey = new SimpleKey("PubKey");
         IKey privKey = new SimpleKey("privKey");
-        Profile newProfile = new Profile("CoolGuy", pubKey, privKey);
+        KeyPair keyPair = new KeyPair(pubKey, privKey);
+        Profile newProfile = new Profile("CoolGuy", keyPair);
         database.addProfile(newProfile);
 
         List<Profile> actual = database.getProfiles();


### PR DESCRIPTION
- Relevant Issues: -
- Related Pull Requests: #83 

* * *

## What
Updated the `Profile` class to use the `KeyPair` class instead of two `IKey`s (one for the public and one for the private key). Also improved the JavaDoc in both classes and updated related tests.

## Why
Makes more sense since the class is available

## How
n/a

## Alternative implementation
The previous implementation was an alternative implementation, but as discussed this was not the best approach.

## Notes
n/a