### PR TITLE
Exclude dependencies and Bluetooth/NFC from cobertura coverage report, closes #110

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,10 @@ android {
     }
 }
 
-cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
+cobertura {
+    coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
+    coverageExcludes = ['.*android.*', '.*cn.pedant.*', '.*com.pnikosis.*']
+}
 
 dependencies {
     compile 'com.android.support:appcompat-v7:25.3.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,13 @@ android {
 
 cobertura {
     coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
-    coverageExcludes = ['.*android.*', '.*cn.pedant.*', '.*com.pnikosis.*']
+    coverageExcludes = [
+            // Exclude dependencies
+            '.*android.*', '.*cn.pedant.*', '.*com.pnikosis.*',
+
+            // Exclude hard to test code
+            '.*com.nervousfish.nervousfish.modules.pairing.*' // Bluetooth/NFC connections
+    ]
 }
 
 dependencies {


### PR DESCRIPTION
- Relevant Issues: #110
- Related Pull Requests: #48

* * *

## What
Exclude certain modules (including dependencies) from the coverage report generated by Cobertura.

## Why
The dependencies coverage are not helpful for the project. Similarly the report on code that is not testable/very hard to test is not very relevant.

## How
You can generate a Cobertura coverage report using `gradle build connectedCheck cobertura` and verify that the specified packages are excluded.

## Alternative implementation
None

## Notes
None