### PR TITLE
Improve implementation of keys to future proof code

### DIFF
--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
@@ -38,10 +38,14 @@ public final class RSAKey implements IKey {
      *
      * @param map A {@link Map} mapping {@link RSAKey} attribute names to values.
      */
-    public RSAKey(final Map<String, String> map) {
+    public RSAKey(final Map<String, String> map) throws IllegalArgumentException {
         this.name = map.get(RSAKey.JSON_CONSTANT_NAME);
         this.modulus = map.get(RSAKey.JSON_CONSTANT_MODULUS);
         this.exponent = map.get(RSAKey.JSON_CONSTANT_EXPONENT);
+
+        if (this.name == null || this.modulus == null || this.exponent == null) {
+           throw new IllegalArgumentException();
+        }
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/RSAKey.java
@@ -1,12 +1,10 @@
 package com.nervousfish.nervousfish.data_objects;
 
-import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.nervousfish.nervousfish.ConstantKeywords;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * RSA variant of {@link IKey}.
@@ -36,24 +34,46 @@ public final class RSAKey implements IKey {
     }
 
     /**
-     * Create a new RSAKey given a {@link JsonReader}.
+     * Constructor for a RSA key given a {@link Map} of its values.
      *
-     * @param reader The {@link JsonReader} to read with.
-     * @return An {@link IKey} representing the JSON key.
-     * @throws IOException When the {@link JsonReader} throws an {@link IOException}.
+     * @param map A {@link Map} mapping {@link RSAKey} attribute names to values.
      */
-    static public IKey fromJSON(final JsonReader reader) throws IOException {
-        final Map<String, String> map = new ConcurrentHashMap<>();
-        while (reader.hasNext()) {
-            final String name = reader.nextName();
-            final String value = reader.nextString();
-            map.put(name, value);
+    public RSAKey(final Map<String, String> map) {
+        this.name = map.get(RSAKey.JSON_CONSTANT_NAME);
+        this.modulus = map.get(RSAKey.JSON_CONSTANT_MODULUS);
+        this.exponent = map.get(RSAKey.JSON_CONSTANT_EXPONENT);
+    }
+
+    /**
+     * Get the exponent of an {@link RSAKey}.
+     *
+     * @param key An {@link RSAKey}.
+     * @return The value for the exponent attribute of the {@code key}.
+     * @throws Exception If the provided {@link IKey} is not a {@link RSAKey}.
+     */
+    public static String getExponent(final IKey key) throws IllegalArgumentException {
+        final String type = key.getType();
+        if (!type.equals(ConstantKeywords.RSA_KEY)) {
+            throw new IllegalArgumentException();
         }
 
-        final String name = map.get(RSAKey.JSON_CONSTANT_NAME);
-        final String modulus = map.get(RSAKey.JSON_CONSTANT_MODULUS);
-        final String exponent = map.get(RSAKey.JSON_CONSTANT_EXPONENT);
-        return new RSAKey(name, modulus, exponent);
+        return ((RSAKey) key).exponent;
+    }
+
+    /**
+     * Get the modulus of an {@link RSAKey}.
+     *
+     * @param key An {@link RSAKey}.
+     * @return The value for the modulus attribute of the {@code key}.
+     * @throws Exception If the provided {@link IKey} is not a {@link RSAKey}.
+     */
+    public static String getModulus(final IKey key) throws IllegalArgumentException {
+        final String type = key.getType();
+        if (!type.equals(ConstantKeywords.RSA_KEY)) {
+            throw new IllegalArgumentException();
+        }
+
+        return ((RSAKey) key).modulus;
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
@@ -1,11 +1,9 @@
 package com.nervousfish.nervousfish.data_objects;
 
-import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Simple variant of {@link IKey}. This is an example implementation of the {@link IKey} interface.
@@ -29,23 +27,13 @@ public final class SimpleKey implements IKey {
     }
 
     /**
-     * Create a new SimpleKey given a {@link JsonReader}.
+     * Constructor for a simple key given a {@link Map} of its values.
      *
-     * @param reader The {@link JsonReader} to read with.
-     * @return An {@link IKey} representing the JSON key.
-     * @throws IOException When the {@link JsonReader} throws an {@link IOException}.
+     * @param map A {@link Map} mapping {@link SimpleKey} attribute names to values.
      */
-    static public IKey fromJSON(final JsonReader reader) throws IOException {
-        final Map<String, String> map = new ConcurrentHashMap<>();
-        while (reader.hasNext()) {
-            final String name = reader.nextName();
-            final String value = reader.nextString();
-            map.put(name, value);
-        }
-
-        final String name = map.get("name");
-        final String key = map.get("key");
-        return new SimpleKey(name, key);
+    public SimpleKey(final Map<String, String> map) {
+        this.name = map.get("name");
+        this.key = map.get("key");
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/data_objects/SimpleKey.java
@@ -31,9 +31,13 @@ public final class SimpleKey implements IKey {
      *
      * @param map A {@link Map} mapping {@link SimpleKey} attribute names to values.
      */
-    public SimpleKey(final Map<String, String> map) {
+    public SimpleKey(final Map<String, String> map) throws IllegalArgumentException {
         this.name = map.get("name");
         this.key = map.get("key");
+
+        if (this.name == null || this.key == null) {
+            throw new IllegalArgumentException();
+        }
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
@@ -9,6 +9,8 @@ import com.nervousfish.nervousfish.data_objects.RSAKey;
 import com.nervousfish.nervousfish.data_objects.SimpleKey;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Adaptor for the {@link IKey} interface for the GSON library.
@@ -49,12 +51,22 @@ final class GsonKeyAdapter extends TypeAdapter<IKey> {
     public IKey read(final JsonReader reader) throws IOException {
         reader.beginArray();
         final String type = reader.nextString();
+
         reader.beginObject();
+        final Map<String, String> map = new ConcurrentHashMap<>();
+        while (reader.hasNext()) {
+            final String name = reader.nextName();
+            final String value = reader.nextString();
+            map.put(name, value);
+        }
+        reader.endObject();
+
+        reader.endArray();
 
         final IKey key;
         switch (type) {
             case ConstantKeywords.RSA_KEY:
-                key = RSAKey.fromJSON(reader);
+                key = new RSAKey(map);
                 break;
             case "simple":
                 key = SimpleKey.fromJSON(reader);
@@ -63,8 +75,6 @@ final class GsonKeyAdapter extends TypeAdapter<IKey> {
                 throw new IOException("Could not read key");
         }
 
-        reader.endObject();
-        reader.endArray();
         return key;
     }
 

--- a/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/database/GsonKeyAdapter.java
@@ -69,7 +69,7 @@ final class GsonKeyAdapter extends TypeAdapter<IKey> {
                 key = new RSAKey(map);
                 break;
             case "simple":
-                key = SimpleKey.fromJSON(reader);
+                key = new SimpleKey(map);
                 break;
             default:
                 throw new IOException("Could not read key");

--- a/app/src/test/java/com/nervousfish/nervousfish/data_objects/RSAKeyTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/data_objects/RSAKeyTest.java
@@ -87,4 +87,28 @@ public class RSAKeyTest {
         assertNotNull(key.hashCode());
     }
 
+    @Test
+    public void testStaticGetModules() {
+        IKey key = new RSAKey("Webmail", "foo", "bar");
+        assertEquals("foo", RSAKey.getModulus(key));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testStaticGetModulesFailsOnNonRSAKey() {
+        IKey key = new SimpleKey("FTP", "foo");
+        RSAKey.getModulus(key);
+    }
+
+    @Test
+    public void testStaticGetExponent() {
+        IKey key = new RSAKey("Webmail", "foo", "bar");
+        assertEquals("bar", RSAKey.getExponent(key));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testStaticGetExponentFailsOnNonRSAKey() {
+        IKey key = new SimpleKey("Webmail", "bar");
+        RSAKey.getExponent(key);
+    }
+
 }

--- a/app/src/test/java/com/nervousfish/nervousfish/data_objects/RSAKeyTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/data_objects/RSAKeyTest.java
@@ -4,6 +4,9 @@ import com.nervousfish.nervousfish.ConstantKeywords;
 
 import org.junit.Test;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -16,6 +19,22 @@ public class RSAKeyTest {
     public void testCanBeInstantiatedWithArbitraryValues() {
         IKey key = new RSAKey("Webmail", "foo", "bar");
         assertNotNull(key);
+    }
+
+    @Test
+    public void testCanBeInstantiatedWithMap() {
+        Map<String, String> map = new ConcurrentHashMap<>();
+        map.put("name", "name");
+        map.put("modulus", "modulus");
+        map.put("exponent", "exponent");
+        IKey key = new RSAKey(map);
+        assertNotNull(key);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testCanBeInstantiatedWithMapMustHaveAllFields() {
+        Map<String, String> map = new ConcurrentHashMap<>();
+        new RSAKey(map);
     }
 
     @Test

--- a/app/src/test/java/com/nervousfish/nervousfish/data_objects/SimpleKeyTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/data_objects/SimpleKeyTest.java
@@ -2,6 +2,9 @@ package com.nervousfish.nervousfish.data_objects;
 
 import org.junit.Test;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -15,6 +18,21 @@ public class SimpleKeyTest {
             IKey key = new SimpleKey("Webmail", "foobar");
             assertNotNull(key);
         }
+
+    @Test
+    public void testCanBeInstantiatedWithMap() {
+        Map<String, String> map = new ConcurrentHashMap<>();
+        map.put("name", "name");
+        map.put("key", "key");
+        IKey key = new SimpleKey(map);
+        assertNotNull(key);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testCanBeInstantiatedWithMapMustHaveAllFields() {
+        Map<String, String> map = new ConcurrentHashMap<>();
+        new SimpleKey(map);
+    }
 
         @Test
         public void testGetNameReturnsNotNull() {


### PR DESCRIPTION
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
Replaced the static methods to create a new `RSAKey` or `SimpleKey` given a `JsonReader` with a constructor that accepts a `Map` that should contain the relevant keys.

Also added two new static methods to the `RSAKey` class which can be used to get the `exponent` and `modulus` of an `RSAKey`.

## Why
The constructor change is a more intuitive solution for the problem and the `RSAKey` static methods for the exponent/modulus might become useful in the future for distributing keys to other apps.

## How
You can run the unittests to verify that all the code in `data_objects` is still covered so it should work correctly

## Alternative implementation
None

## Notes
None