### PR TITLE
Add integration support for BetterCodeHub

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,3 @@
+component_depth: 1
+languages:
+- java

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="PROJECT_PROFILE" value="Project Default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NervousFish
 [![Build Status](https://travis-ci.org/ericcornelissen/NervousFish.svg?branch=develop)](https://travis-ci.org/ericcornelissen/NervousFish)
 [![Coverage Status](https://coveralls.io/repos/github/ericcornelissen/NervousFish/badge.svg?branch=master)](https://coveralls.io/github/ericcornelissen/NervousFish?branch=master)
+[![BCH compliance](https://bettercodehub.com/edge/badge/ericcornelissen/NervousFish?branch=develop)](https://bettercodehub.com/)
 
 An app for your :iphone: to exchange public-keys in a secure manner.
 


### PR DESCRIPTION
<!-- Check if the title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
This PR adds support for integration with BetterCodeHub by adding a default config file and a README.md badge

## Why
This Pull Request is needed because it gives insight into the quality of the code in the repository.

## How
You can see the badge in the [README](https://github.com/ericcornelissen/NervousFish/tree/quality/bettercodehub) and as a collaborator you should be able to see the BetterCodeHub results from the dashboard on their site.

## Alternative implementation
None

## Notes
You can find out more about BetterCodeHub at [their site](https://bettercodehub.com/)
