### PR TITLE
Hide pairing menu

### DIFF
--- a/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
@@ -11,6 +11,7 @@ import android.widget.ExpandableListView;
 import android.widget.ListView;
 import android.widget.ViewFlipper;
 
+import com.github.clans.fab.FloatingActionMenu;
 import com.nervousfish.nervousfish.ConstantKeywords;
 import com.nervousfish.nervousfish.R;
 import com.nervousfish.nervousfish.data_objects.Contact;
@@ -148,6 +149,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onBluetoothButtonMainActivityClick(final View view) {
         LOGGER.info("Bluetooth button clicked");
+        ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
         final Intent intent = new Intent(this, ActivateBluetoothActivity.class);
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
         this.startActivity(intent);
@@ -160,6 +162,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onNFCButtonMainActivityClick(final View view) {
         LOGGER.info("NFC button clicked");
+        ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
         final Intent intent = new Intent(this, NFCActivity.class);
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
         this.startActivity(intent);
@@ -172,6 +175,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onQRButtonMainActivityClick(final View view) {
         LOGGER.info("QR button clicked");
+        ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
         final Intent intent = new Intent(this, QRActivity.class);
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
         this.startActivity(intent);

--- a/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
@@ -149,7 +149,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onBluetoothButtonMainActivityClick(final View view) {
         LOGGER.info("Bluetooth button clicked");
-        pairingButtonClicked(ActivateBluetoothActivity.class);
+        pairingButtonClicked(view);
     }
 
     /**
@@ -159,7 +159,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onNFCButtonMainActivityClick(final View view) {
         LOGGER.info("NFC button clicked");
-        pairingButtonClicked(NFCActivity.class);
+        pairingButtonClicked(view);
     }
 
     /**
@@ -169,7 +169,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onQRButtonMainActivityClick(final View view) {
         LOGGER.info("QR button clicked");
-        pairingButtonClicked(QRActivity.class);
+        pairingButtonClicked(view);
     }
 
     /**
@@ -214,13 +214,27 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Goes to the activity specified after clicking a pairing button
+     * Goes to the activity associated with the view after clicking a pairing button
      *
-     * @param activity The activity to go to
+     * @param view The view that was clicked
      */
-    private void pairingButtonClicked(final Class<?> activity) {
+    private void pairingButtonClicked(final View view) {
         ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
-        final Intent intent = new Intent(this, activity);
+        final Intent intent;
+        switch (view.getId()) {
+            case R.id.pairing_menu_bluetooth:
+                intent = new Intent(this, ActivateBluetoothActivity.class);
+                break;
+            case R.id.pairing_menu_nfc:
+                intent = new Intent(this, NFCActivity.class);
+                break;
+            case R.id.pairing_menu_qr:
+                intent = new Intent(this, QRActivity.class);
+                break;
+            default:
+                LOGGER.error("Unknown pairing button clicked");
+                throw new IllegalArgumentException("Only existing buttons can be clicked");
+        }
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
         this.startActivity(intent);
     }

--- a/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
@@ -149,10 +149,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onBluetoothButtonMainActivityClick(final View view) {
         LOGGER.info("Bluetooth button clicked");
-        ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
-        final Intent intent = new Intent(this, ActivateBluetoothActivity.class);
-        intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
-        this.startActivity(intent);
+        pairingButtonClicked(ActivateBluetoothActivity.class);
     }
 
     /**
@@ -162,10 +159,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onNFCButtonMainActivityClick(final View view) {
         LOGGER.info("NFC button clicked");
-        ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
-        final Intent intent = new Intent(this, NFCActivity.class);
-        intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
-        this.startActivity(intent);
+        pairingButtonClicked(NFCActivity.class);
     }
 
     /**
@@ -175,10 +169,7 @@ public final class MainActivity extends AppCompatActivity {
      */
     public void onQRButtonMainActivityClick(final View view) {
         LOGGER.info("QR button clicked");
-        ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
-        final Intent intent = new Intent(this, QRActivity.class);
-        intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
-        this.startActivity(intent);
+        pairingButtonClicked(QRActivity.class);
     }
 
     /**
@@ -220,6 +211,18 @@ public final class MainActivity extends AppCompatActivity {
     protected void onStop() {
         this.serviceLocator.unregisterFromEventBus(this);
         super.onStop();
+    }
+
+    /**
+     * Goes to the activity specified after clicking a pairing button
+     *
+     * @param activity The activity to go to
+     */
+    private void pairingButtonClicked(final Class<?> activity) {
+        ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
+        final Intent intent = new Intent(this, activity);
+        intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
+        this.startActivity(intent);
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
@@ -143,36 +143,6 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Gets triggered when the Bluetooth button is clicked.
-     *
-     * @param view - the ImageButton
-     */
-    public void onBluetoothButtonMainActivityClick(final View view) {
-        LOGGER.info("Bluetooth button clicked");
-        pairingButtonClicked(view);
-    }
-
-    /**
-     * Gets triggered when the NFC button is clicked.
-     *
-     * @param view - the ImageButton
-     */
-    public void onNFCButtonMainActivityClick(final View view) {
-        LOGGER.info("NFC button clicked");
-        pairingButtonClicked(view);
-    }
-
-    /**
-     * Gets triggered when the QR button is clicked.
-     *
-     * @param view - the ImageButton
-     */
-    public void onQRButtonMainActivityClick(final View view) {
-        LOGGER.info("QR button clicked");
-        pairingButtonClicked(view);
-    }
-
-    /**
      * Switches the sorting mode.
      *
      * @param view The sort floating action button that was clicked
@@ -218,7 +188,7 @@ public final class MainActivity extends AppCompatActivity {
      *
      * @param view The view that was clicked
      */
-    private void pairingButtonClicked(final View view) {
+    public void onPairingButtonClicked(final View view) {
         ((FloatingActionMenu) findViewById(R.id.pairing_button)).close(true);
         final Intent intent;
         switch (view.getId()) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -66,7 +66,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@android:drawable/stat_sys_data_bluetooth"
-            android:onClick="onBluetoothButtonMainActivityClick"
+            android:onClick="onPairingButtonClicked"
             fab:fab_label="@string/bluetooth" />
 
         <com.github.clans.fab.FloatingActionButton
@@ -75,7 +75,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/nfc_variant"
-            android:onClick="onNFCButtonMainActivityClick"
+            android:onClick="onPairingButtonClicked"
             fab:fab_label="@string/nfc" />
 
         <com.github.clans.fab.FloatingActionButton
@@ -83,7 +83,7 @@
             style="@style/MenuButtonsStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:onClick="onQRButtonMainActivityClick"
+            android:onClick="onPairingButtonClicked"
             android:src="@drawable/qr_code"
             fab:fab_label="@string/qr" />
 


### PR DESCRIPTION
<!-- Check if the title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
This Pull Request adds to the repository the hiding of the pairing menu after a button is clicked

## Why
This Pull Request is needed because it's neat that it's hided after you clicked one of the available options of the menu

## How
This feature can be viewed/tested within the project by opening the menu, clicking a pairing button, going back to the main activity and verifying that the button is closed

## Alternative implementation
Other implementations that I've have considered are 

## Notes
<!-- Is there anything reviewers need to know about? Do they need to take something into account while
reviewing? Is there something they should pay extra attention to? -->
