### PR TITLE
Close the Enable Bluetooth popup on phones during androidTest

### DIFF
--- a/app/src/androidTest/java/com/nervousfish/nervousfish/test/MainSteps.java
+++ b/app/src/androidTest/java/com/nervousfish/nervousfish/test/MainSteps.java
@@ -1,6 +1,7 @@
 package com.nervousfish.nervousfish.test;
 
 import android.content.Intent;
+import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.rule.ActivityTestRule;
 
 import com.nervousfish.nervousfish.BaseTest;
@@ -47,7 +48,11 @@ public class MainSteps {
     public void iAmViewingMainActivity() throws IOException {
         final Intent intent = new Intent();
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
-        mActivityRule.launchActivity(intent);
+        this.mActivityRule.launchActivity(intent);
+
+        try {
+            onView(withText(R.string.no)).perform(click());
+        } catch (NoMatchingViewException ignore) { }
     }
 
     @When("^I click the back button in main and go to the LoginActivity$")


### PR DESCRIPTION
<!-- Check if the title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
This Pull Request adds to the MainActivity steps an extra statement which, only on phones with Bluetooth, closes the popup requesting the user to enable Bluetooth.

## Why
This Pull Request is needed because otherwise running tests on an actual phone is a pain.

## How
This feature can be viewed/tested within the project by running the androidTests twice, once on an emulator and once on an actual phone and see if all the tests still work.

## Alternative implementation
None

## Notes
None
