### PR TITLE
Remove demo database contents from the app, closes #226

### DIFF
--- a/app/src/androidTest/assets/features/main.feature
+++ b/app/src/androidTest/assets/features/main.feature
@@ -13,13 +13,25 @@ Feature: Main Activity
     And I verify that I do not want to log out
     Then I should stay in the main activity after pressing back
 
+  Scenario Outline: Clicking on a contact in the list of contacts
+    Given there is a contact with the name <name> in the database
+    And I am viewing the main activity
+    When I click on the contact with the name <name>
+    Then I should go to the contact activity from main
+
+    Examples:
+      | name     |
+      | Henk     |
+      | Zoidberg |
+      | Dr. Evil |
+
   Scenario: Clicking the QR button
       Given I am viewing the main activity
       When I click open buttons with the plus
       And I click the button with the QR icon
       Then I should go to the QR activity from main
 
-  Scenario: Clicking the QR button text
+  Scenario: Clicking the QR button label
         Given I am viewing the main activity
         When I click open buttons with the plus
         And I click the button with the QR text label

--- a/app/src/androidTest/java/com/nervousfish/nervousfish/test/MainSteps.java
+++ b/app/src/androidTest/java/com/nervousfish/nervousfish/test/MainSteps.java
@@ -1,7 +1,6 @@
 package com.nervousfish.nervousfish.test;
 
 import android.content.Intent;
-import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.rule.ActivityTestRule;
 
 import com.nervousfish.nervousfish.BaseTest;
@@ -54,10 +53,6 @@ public class MainSteps {
         final Intent intent = new Intent();
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
         this.mActivityRule.launchActivity(intent);
-
-        try {
-            onView(withText(R.string.no)).perform(click());
-        } catch (NoMatchingViewException ignore) { }
     }
 
     @Given("^there is a contact with the name (.*?) in the database$")

--- a/app/src/androidTest/java/com/nervousfish/nervousfish/test/MainSteps.java
+++ b/app/src/androidTest/java/com/nervousfish/nervousfish/test/MainSteps.java
@@ -1,14 +1,20 @@
 package com.nervousfish.nervousfish.test;
 
 import android.content.Intent;
+import android.support.test.espresso.NoMatchingViewException;
 import android.support.test.rule.ActivityTestRule;
 
 import com.nervousfish.nervousfish.BaseTest;
 import com.nervousfish.nervousfish.ConstantKeywords;
 import com.nervousfish.nervousfish.R;
+import com.nervousfish.nervousfish.activities.ContactActivity;
 import com.nervousfish.nervousfish.activities.LoginActivity;
 import com.nervousfish.nervousfish.activities.MainActivity;
 import com.nervousfish.nervousfish.activities.QRExchangeKeyActivity;
+import com.nervousfish.nervousfish.data_objects.Contact;
+import com.nervousfish.nervousfish.data_objects.IKey;
+import com.nervousfish.nervousfish.data_objects.RSAKey;
+import com.nervousfish.nervousfish.modules.database.IDatabase;
 import com.nervousfish.nervousfish.service_locator.IServiceLocator;
 import com.nervousfish.nervousfish.service_locator.ServiceLocator;
 
@@ -44,10 +50,23 @@ public class MainSteps {
             new ActivityTestRule<>(MainActivity.class, true, false);
 
     @Given("^I am viewing the main activity$")
-    public void iAmViewingMainActivity() throws IOException {
+    public void iAmViewingMainActivity() {
         final Intent intent = new Intent();
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
-        mActivityRule.launchActivity(intent);
+        this.mActivityRule.launchActivity(intent);
+
+        try {
+            onView(withText(R.string.no)).perform(click());
+        } catch (NoMatchingViewException ignore) { }
+    }
+
+    @Given("^there is a contact with the name (.*?) in the database$")
+    public void thereIsAContactInTheDatabaseWithTheName(final String name) throws IOException {
+        final IKey key = new RSAKey("Email", "42", "13");
+        final Contact contact = new Contact(name, key);
+
+        final IDatabase database = this.serviceLocator.getDatabase();
+        database.addContact(contact);
     }
 
     @When("^I click the back button in main and go to the LoginActivity$")
@@ -76,6 +95,11 @@ public class MainSteps {
         onView(withId(R.id.pairing_menu_qr)).perform(click());
     }
 
+    @When("^I click on the contact with the name (.*?)$")
+    public void iClockOnTheContactWithTheName(final String name) {
+        onView(withText(name)).perform(click());
+    }
+
     @When("^I click the button with the QR text label$")
     public void iClickQRLabel() {
         onView(withText(R.string.qr)).perform(click());
@@ -95,4 +119,10 @@ public class MainSteps {
     public void iShouldGoToTheQRActivity() {
         intended(hasComponent(QRExchangeKeyActivity.class.getName()));
     }
+
+    @Then("^I should go to the contact activity from main$")
+    public void iShouldGoToTheContactActivity() {
+        intended(hasComponent(ContactActivity.class.getName()));
+    }
+
 }

--- a/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/MainActivity.java
@@ -15,10 +15,7 @@ import com.github.clans.fab.Label;
 import com.nervousfish.nervousfish.ConstantKeywords;
 import com.nervousfish.nervousfish.R;
 import com.nervousfish.nervousfish.data_objects.Contact;
-import com.nervousfish.nervousfish.data_objects.IKey;
-import com.nervousfish.nervousfish.data_objects.SimpleKey;
 import com.nervousfish.nervousfish.exceptions.NoBluetoothException;
-import com.nervousfish.nervousfish.modules.database.IDatabase;
 import com.nervousfish.nervousfish.modules.pairing.events.BluetoothConnectedEvent;
 import com.nervousfish.nervousfish.service_locator.IServiceLocator;
 
@@ -28,8 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import cn.pedant.SweetAlert.SweetAlertDialog;
@@ -79,9 +74,6 @@ public final class MainActivity extends AppCompatActivity {
             getSupportActionBar().setDisplayShowTitleEnabled(false);
         }
         try {
-            if (this.serviceLocator.getDatabase().getAllContacts().isEmpty()) {
-                fillDatabaseWithDemoData();
-            }
             this.contacts = this.serviceLocator.getDatabase().getAllContacts();
         } catch (final IOException e) {
             LOGGER.error("Failed to retrieve contacts from database", e);
@@ -221,33 +213,6 @@ public final class MainActivity extends AppCompatActivity {
         intent.putExtra(ConstantKeywords.SERVICE_LOCATOR, this.serviceLocator);
         intent.putExtra(ConstantKeywords.CONTACT, this.contacts.get(index));
         this.startActivity(intent);
-    }
-
-
-
-    /**
-     * Temporarily fill the database with demo data for development.
-     * Checkstyle is disabled, because this method is only temporarily
-     */
-    @SuppressWarnings("checkstyle:multipleStringLiterals")
-    private void fillDatabaseWithDemoData() throws IOException {
-        final IDatabase database = this.serviceLocator.getDatabase();
-        final Collection<IKey> keys = new ArrayList<>();
-        keys.add(new SimpleKey("Webmail", "jdfs09jdfs09jfs0djfds9jfsd0"));
-        keys.add(new SimpleKey("Webserver", "jasdgoijoiahl328hg09asdf322"));
-        final Contact a = new Contact("Eric", keys);
-        final Contact b = new Contact("Stas", new SimpleKey("FTP", "4ji395j495i34j5934ij534i"));
-        //final Contact c = new Contact("Joost", new SimpleKey("Webserver", "dnfh4nl4jknlkjnr4j34klnk3j4nl"));
-        //final Contact d = new Contact("Kilian", new SimpleKey("Webmail", "sdjnefiniwfnfejewjnwnkenfk32"));
-        //final Contact e = new Contact("Cornel", new SimpleKey("Awesomeness", "nr23uinr3uin2o3uin23oi4un234ijn"));
-
-        final List<Contact> contacts = database.getAllContacts();
-        for (final Contact contact : contacts) {
-            database.deleteContact(contact.getName());
-        }
-
-        database.addContact(a);
-        database.addContact(b);
     }
 
     /**


### PR DESCRIPTION
<!-- Check if the title is descriptive! -->
- Relevant Issues: #226 
- Related Pull Requests: -

* * *

## What
This Pull Request removes from the repository the demo database content loaded in the `MainActivity`. Besides that it also adds an androidTest for clicking on a contact in the MainActivity.

## Why
This Pull Request is needed because the demo database content is no longer needed or useful, since we can now exchange contacts.

## How
This feature can be viewed/tested within the project by opening the app and looking at the contacts list in the `MainActivity`. Beware that it may contact contacts inserted during androidTests!

## Alternative implementation
n/a

## Notes
None