### PR TITLE
Removed the Java logging PMD ruleset

### DIFF
--- a/config/quality/pmd/pmd-ruleset.xml
+++ b/config/quality/pmd/pmd-ruleset.xml
@@ -17,12 +17,16 @@
     <rule ref="rulesets/java/controversial.xml" >
         <!-- Often you use a variable only in a single method, but the variable should stay constant in that method -->
         <exclude name="AvoidFinalLocalVariable" />
+
         <!-- Sometimes we have to use package-private classes -->
         <exclude name="DefaultPackage" />
+
         <!-- Multiple returns are allowed in some cases, but have to be used with caution -->
         <exclude name="OnlyOneReturn" />
+
         <!-- Very useful in C++, but not in Java -->
         <exclude name="DataflowAnomalyAnalysis" />
+        
         <!-- Many classes don't need an explicit empty constructor (like activities) -->
         <exclude name="AtLeastOneConstructor" />
     </rule>
@@ -35,14 +39,10 @@
     <rule ref="rulesets/java/empty.xml" />
     <rule ref="rulesets/java/finalizers.xml" />
     <rule ref="rulesets/java/imports.xml">
-        <!-- Espresso is designed this way !-->
+        <!-- Espresso is designed this way -->
         <exclude name="TooManyStaticImports" />
     </rule>
     <rule ref="rulesets/java/junit.xml" />
-    <rule ref="rulesets/java/logging-java.xml">
-        <!-- This rule wasn't working properly and given errors in every var call info -->
-        <exclude name="GuardLogStatementJavaUtil" />
-    </rule>
     <rule ref="rulesets/java/naming.xml">
         <exclude name="AbstractNaming" />
         <exclude name="LongVariable" />


### PR DESCRIPTION
<!-- Check if the title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
This Pull Request removes the PMD `rulesets/java/logging-java.xml` ruleset.

## Why
Because the ruleset is not implemented properly and it caused the build log to [blow up](https://travis-ci.org/ericcornelissen/NervousFish/builds/241056759#L2841) with `RuntimeExceptions`.

## How
This feature can be viewed/tested within the project by viewing the build logs on Travis for this PR or running `gradle build` locally. You'll see that PMD no longer throws a bunch of `RuntimeExceptions`.

## Alternative implementation
I've considered updating the ruleset or the ruleset version of PMD but neither worked... 😕 

## Notes
None
