### PR TITLE
Throw and test the Deserialization exception

### DIFF
--- a/app/src/main/java/com/nervousfish/nervousfish/modules/pairing/APairingHandler.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/pairing/APairingHandler.java
@@ -49,6 +49,7 @@ abstract class APairingHandler implements IPairingHandler {
                 this.serviceLocator.postOnEventBus(new NewDataReceivedEvent(object.getData(), object.getClazz()));
             } catch (final ClassNotFoundException | IOException e) {
                 LOGGER.error(" Couldn't start deserialization!", e);
+                throw new DeserializationException(e);
             }
         });
     }

--- a/app/src/main/java/com/nervousfish/nervousfish/modules/pairing/DeserializationException.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/pairing/DeserializationException.java
@@ -1,4 +1,4 @@
-package com.nervousfish.nervousfish.exceptions;
+package com.nervousfish.nervousfish.modules.pairing;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -19,6 +19,15 @@ public final class DeserializationException extends RuntimeException {
      */
     public DeserializationException(final String msg) {
         super(msg);
+    }
+
+    /**
+     * Constructs a new DeserializationException that's thrown when there is an issue with
+     * deserialization.
+     * @param e The exception that occurred that caused this throwable to happen
+     */
+    public DeserializationException(final Exception e) {
+        super(e);
     }
 
     /**

--- a/app/src/main/java/com/nervousfish/nervousfish/modules/pairing/DeserializationException.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/modules/pairing/DeserializationException.java
@@ -7,7 +7,7 @@ import java.io.ObjectOutputStream;
 /**
  * Thrown when there is an issue with deserialization.
  */
-public final class DeserializationException extends RuntimeException {
+final class DeserializationException extends RuntimeException {
 
     private static final long serialVersionUID = -1930461199728515311L;
 
@@ -17,17 +17,17 @@ public final class DeserializationException extends RuntimeException {
      *
      * @param msg A string describing the event
      */
-    public DeserializationException(final String msg) {
+    DeserializationException(final String msg) {
         super(msg);
     }
 
     /**
      * Constructs a new DeserializationException that's thrown when there is an issue with
      * deserialization.
-     * @param e The exception that occurred that caused this throwable to happen
+     * @param throwable The exception that occurred that caused this throwable to happen
      */
-    public DeserializationException(final Exception e) {
-        super(e);
+    DeserializationException(final Throwable throwable) {
+        super(throwable);
     }
 
     /**

--- a/app/src/test/java/com/nervousfish/nervousfish/modules/pairing/DeserializationExceptionTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/modules/pairing/DeserializationExceptionTest.java
@@ -1,0 +1,51 @@
+package com.nervousfish.nervousfish.modules.pairing;
+
+import com.nervousfish.nervousfish.modules.cryptography.KeyGenerationException;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.Assert.assertTrue;
+
+public class DeserializationExceptionTest {
+    @Test
+    public void testExceptionConstructorString() {
+        DeserializationException keyGenerationException = new DeserializationException("foo");
+        assertTrue(keyGenerationException.getMessage().equals("foo"));
+    }
+    @Test
+    public void testExceptionConstructorThrowable() {
+        final Exception exception = new Exception();
+        DeserializationException keyGenerationException = new DeserializationException(exception);
+        assertTrue(keyGenerationException.getCause().equals(exception));
+    }
+
+    @Test
+    public void testThrowableConstructor() {
+        final Throwable throwable = new Throwable();
+        DeserializationException keyGenerationException = new DeserializationException(throwable);
+        assertTrue(keyGenerationException.getCause().equals(throwable));
+    }
+
+    @Test
+    public void testSerialization() throws IOException, ClassNotFoundException {
+        final DeserializationException exception = new DeserializationException(new Exception());
+        try (
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(bos)
+                ) {
+            oos.writeObject(exception);
+            byte[] bytes = bos.toByteArray();
+            try (ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+                 ObjectInputStream ois = new ObjectInputStream(bis)) {
+                Object exception1 = ois.readObject();
+                assertTrue(exception1.getClass().equals(DeserializationException.class));
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Check if the title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
This Pull Request
- lets DataReceiver throw a DeserializationException when something went wrong with the deserialization
- Tests the DeserializationException

## Why
This Pull Request is needed because no exception was thrown when something went wrong while deserializing

## How
This feature can be viewed/tested within the project by -

## Alternative implementation
Other implementations that I've have considered are 

## Notes
<!-- Is there anything reviewers need to know about? Do they need to take something into account while
reviewing? Is there something they should pay extra attention to? -->
