### PR TITLE
Increase the number of required blocks in the visual verification method

### DIFF
--- a/app/src/androidTest/assets/features/visual_verification.feature
+++ b/app/src/androidTest/assets/features/visual_verification.feature
@@ -8,11 +8,12 @@ Feature: Visual verification
     And I press button <third_button> in the verification grid
     And I press button <fourth_button> in the verification grid
     And I press button <fifth_button> in the verification grid
+    And I press button <sixth_button> in the verification grid
     Then I leave the visual verification activity
 
     Examples:
-      | first_button  | second_button | third_button | fourth_button | fifth_button |
-      | 1             | 3             | 2            | 5             | 9            |
-      | 9             | 1             | 3            | 10            | 1            |
-      | 2             | 4             | 2            | 4             | 2            |
-      | 2             | 10            | 7            | 11            | 8            |
+      | first_button  | second_button | third_button | fourth_button | fifth_button | sixth_button |
+      | 1             | 3             | 2            | 5             | 9            | 10           |
+      | 9             | 1             | 3            | 10            | 1            | 1            |
+      | 2             | 4             | 2            | 4             | 2            | 5            |
+      | 2             | 10            | 7            | 11            | 8            | 4            |

--- a/app/src/main/java/com/nervousfish/nervousfish/activities/VisualVerificationActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/VisualVerificationActivity.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 public final class VisualVerificationActivity extends Activity {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("VisualVerificationActivity");
-    private static final int SECURITY_CODE_LENGTH = 5;
+    private static final int SECURITY_CODE_LENGTH = 6;
     private static final int NUM_BUTTONS = 12;
 
     private IServiceLocator serviceLocator;


### PR DESCRIPTION
<!-- Check if the pull request title is descriptive! -->
- Relevant Issues: #286
- Related Pull Requests: -

* * *

## What
<!-- Specify what this pull request adds to the project -->
This Pull Request updates the repository so it is required to select **6** (instead of 5) tabs in the `VisualVerificationActivity`.

## Why
<!-- Specify why this issue is needed in the project -->
This Pull Request is needed because it increases the possible entropy of the verification methods, making it more secure. The entropy is increased from `12^5 = 248.832` to `12^6 = 2.985.984`

## How
<!-- Specify how this feature can be viewed or tested -->
This feature can be viewed/tested within the project by opening the app, start a Bluetooth connection and select the Visual verification method, you'll see that you have to select 6 blocks before continuing.

## Alternative implementation
<!-- Specify any alternative implementations you have considered -->
n/a

## Notes
<!-- Is there anything important reviewers should know? Do they need to take something into account while reviewing? -->
None
