### PR TITLE
Clear the password in the LoginActivity

### DIFF
--- a/app/src/main/java/com/nervousfish/nervousfish/activities/LoginActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/LoginActivity.java
@@ -85,7 +85,17 @@ public final class LoginActivity extends AppCompatActivity {
      * Go to the next activity from the {@link LoginActivity}.
      */
     private void toMainActivity() {
+        this.clearPasswordInput(); // Clear the input for security
         final Intent intent = new Intent(this, MainActivity.class);
         this.startActivity(intent);
     }
+
+    /**
+     * Clear the password input.
+     */
+    private void clearPasswordInput() {
+        final EditText passwordInput = (EditText) this.findViewById(R.id.login_password_input);
+        passwordInput.setText("");
+    }
+
 }


### PR DESCRIPTION
<!-- Check if the pull request title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
<!-- Specify what this pull request adds to the project -->
This Pull Request updates the code base so the password entered in the login screen is cleared once the app progresses to the `MainActivity`.

## Why
<!-- Specify why this issue is needed in the project -->
This Pull Request is needed because it improves security. Now it is sometimes possible to get back to the `LoginActivity`, and then the password is still there 😕 

## How
<!-- Specify how this feature can be viewed or tested -->
It is pretty hard to test this future, unless you know a way to cause your phone to get to the `LoginActivity` in an unexpected fashion. On my device, if the app crashes I immediately go back to the `LoginActivity` and then the password would still be there.

## Alternative implementation
<!-- Specify any alternative implementations you have considered -->
- Clear the input if the `LoginActivity` is created. Simply seemed like a worse idea then the current implementation.

## Notes
<!-- Is there anything important reviewers should know? Do they need to take something into account while reviewing? -->
None
