### PR TITLE
Fit the NFC gif properly in the activity

### DIFF
--- a/app/src/main/res/layout/activity_nfc.xml
+++ b/app/src/main/res/layout/activity_nfc.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:weightSum="1"
-    tools:ignore = "UseCompoundDrawables">
+    android:background="@color/white"
+    tools:ignore="UseCompoundDrawables">
 
     <ImageView
         android:id="@+id/nfc_gif"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:scaleType="fitXY"
         android:contentDescription="@string/nfc_image_description"
         android:src="@android:drawable/sym_def_app_icon" />
 
@@ -21,7 +22,5 @@
         android:contentDescription="@string/nfc_explanation"
         android:text="@string/nfc_explanation"
         android:gravity="center"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentStart="true" />
-
+        android:layout_alignParentTop="true" />
 </RelativeLayout>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -111,7 +111,7 @@
 
     <!-- NFC -->
     <string name="nfc_image_description">Dit zou een gif moeten zijn die nfc connection uitbeeldt.</string>
-    <string name="nfc_explanation">Breng uw toestel zo dicht mogelijk bij het gewenste andere toestel om contacten uit te wisselen.</string>
+    <string name="nfc_explanation">Breng uw toestel zo dicht mogelijk bij het gewenste andere toestel om sleutels uit te wisselen.</string>
     <string name="popup_enable_nfc_title">NFC aanzetten?</string>
     <string name="popup_enable_nfc_settings">Activeer a.u.b. NFC in de instellingen en click de terug knop om terug te gaan naar de app</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
 
     <!-- NFC -->
     <string name="nfc_image_description">This should be a gif representing the use of NFC.</string>
-    <string name="nfc_explanation">Please bring your device as close as possible to another device you want to exchange contacts with.</string>
+    <string name="nfc_explanation">Please bring your device as close as possible to another device you want to exchange keys with.</string>
     <string name="popup_enable_nfc_title">Enable NFC?</string>
     <string name="popup_enable_nfc_settings">Please activate NFC and press Back to return to the application!</string>
 


### PR DESCRIPTION
<!-- Check if the pull request title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
<!-- Specify what this pull request adds to the project -->
This Pull Request updates the NFC activity layout so the image is displayed on the whole screen. Also changed the word "Contact" in the NFC description to "Key".

## Why
<!-- Specify why this issue is needed in the project -->
This Pull Request is needed because it improves the look of the activity.

## How
<!-- Specify how this feature can be viewed or tested -->
This feature can be viewed/tested within the project by opening the app and going to the NFC activity.

## Alternative implementation
<!-- Specify any alternative implementations you have considered -->
Other implementations that I've have considered are:
- Using a `RelativeLayout` and put the text above the image, didn't look that good imo.

## Notes
<!-- Is there anything important reviewers should know? Do they need to take something into account while reviewing? -->
None
