### PR TITLE
Auto capitalization for profile name input in create profile activity

### DIFF
--- a/app/src/main/res/layout/activity_create_profile.xml
+++ b/app/src/main/res/layout/activity_create_profile.xml
@@ -42,7 +42,7 @@
                 android:layout_height="match_parent"
                 android:layout_toEndOf="@+id/icon_name_create_profile"
                 android:hint="@string/name"
-                android:inputType="text"
+                android:inputType="textCapWords"
                 android:maxLines="1" />
         </RelativeLayout>
 


### PR DESCRIPTION
<!-- Check if the pull request title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: #171 

* * *

## What
<!-- Specify what this pull request adds to the project -->
This Pull Request updates the `activity_create_profile.xml` so the input for the users name is capitalized per word, as one would expect for a name.

## Why
<!-- Specify why this issue is needed in the project -->
This Pull Request is needed because it improves the user experience when creating a new profile.

## How
<!-- Specify how this feature can be viewed or tested -->
This feature can be viewed/tested within the project by uninstalling the app, reinstalling the app and creating a new profile. You'll see that the input for the name will be capitalized per word.

## Alternative implementation
<!-- Specify any alternative implementations you have considered -->
None considered

## Notes
<!-- Is there anything important reviewers should know? Do they need to take something into account while reviewing? -->
None
