### PR TITLE
Allow rhythms of the same length

### DIFF
--- a/app/src/main/java/com/nervousfish/nervousfish/activities/RhythmVerificationActivity.java
+++ b/app/src/main/java/com/nervousfish/nervousfish/activities/RhythmVerificationActivity.java
@@ -45,6 +45,7 @@ public final class RhythmVerificationActivity extends AppCompatActivity {
     private static final int MINIMUM_TAPS = 3;
     private static final int DECIMAL_SIZE = 10;
     private static final int MAX_RHYTHM_ENCODING = 10;
+    private static final double INTERVALS_SAME_SIZE_THRESHOLD = 0.75;
 
     private Button startButton;
     private Button stopButton;
@@ -235,6 +236,18 @@ public final class RhythmVerificationActivity extends AppCompatActivity {
             return intervals;
         }
 
+        private static boolean intervalsSameSize(final List<Long> intervals) {
+            long shortest = Long.MAX_VALUE;
+            long longest = Long.MIN_VALUE;
+
+            for (final long interval : intervals) {
+                shortest = Math.min(interval, shortest);
+                longest = Math.max(interval, longest);
+            }
+
+            return (double) shortest / (double) longest > INTERVALS_SAME_SIZE_THRESHOLD;
+        }
+
         /**
          * Returns the unique key that corresponds to the taps specified.
          * The key is a binary number.
@@ -251,6 +264,9 @@ public final class RhythmVerificationActivity extends AppCompatActivity {
             this.clusterCenter1 = new ArrayList<>(taps.size());
             this.clusterCenter2 = new ArrayList<>(taps.size());
             this.intervals = getIntervals(taps);
+            if (intervalsSameSize(this.intervals)) {
+                return addNumIntervalsToKey(0L);
+            }
             long clusterCenterMean1 = this.makeAndReturnFirstClusterMean();
             long clusterCenterMean2 = this.makeAndReturnSecondClusterMean();
 
@@ -375,6 +391,11 @@ public final class RhythmVerificationActivity extends AppCompatActivity {
                     counter++;
                 }
             }
+            return addNumIntervalsToKey(key);
+        }
+
+        private long addNumIntervalsToKey(final long keyIn) {
+            long key = keyIn;
             long tmpIntervalSize = this.intervals.size();
             int startValue = 1;
             while (tmpIntervalSize >= startValue * DECIMAL_SIZE) {

--- a/app/src/test/java/com/nervousfish/nervousfish/activities/KMeansClusterHelperTest.java
+++ b/app/src/test/java/com/nervousfish/nervousfish/activities/KMeansClusterHelperTest.java
@@ -11,13 +11,11 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class KMeansClusterHelperTest {
     @Test
     public void testGetEncryptionKey() throws Exception {
-        RhythmVerificationActivity activity = new RhythmVerificationActivity();
-
         final List<SingleTap> taps = new ArrayList<>();
         taps.add(new SingleTap(new Timestamp(0)));
         taps.add(new SingleTap(new Timestamp(5)));
@@ -83,7 +81,7 @@ public class KMeansClusterHelperTest {
         final List<SingleTap> taps = new ArrayList<>();
         taps.add(new SingleTap(new Timestamp(0)));
         taps.add(new SingleTap(new Timestamp(5)));
-        taps.add(new SingleTap(new Timestamp(11)));
+        taps.add(new SingleTap(new Timestamp(13)));
 
         Class<?> kMeansClusterHelperClass = Class.forName("com.nervousfish.nervousfish.activities.RhythmVerificationActivity$KMeansClusterHelper");
         Constructor<?> constructor = kMeansClusterHelperClass.getDeclaredConstructor();
@@ -188,5 +186,25 @@ public class KMeansClusterHelperTest {
         Method method = kMeansClusterHelperClass.getDeclaredMethod("getEncryptionKey", List.class);
         method.setAccessible(true);
         method.invoke(kMeansClusterHelper, taps);
+    }
+
+    @Test
+    public void testGetEncryptionKeySameSize() throws Exception {
+        final List<SingleTap> taps = new ArrayList<>();
+        taps.add(new SingleTap(new Timestamp(0)));
+        taps.add(new SingleTap(new Timestamp(50)));
+        taps.add(new SingleTap(new Timestamp(98)));
+        taps.add(new SingleTap(new Timestamp(148)));
+        taps.add(new SingleTap(new Timestamp(201)));
+
+        Class<?> kMeansClusterHelperClass = Class.forName("com.nervousfish.nervousfish.activities.RhythmVerificationActivity$KMeansClusterHelper");
+        Constructor<?> constructor = kMeansClusterHelperClass.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Object kMeansClusterHelper = constructor.newInstance();
+        Method method = kMeansClusterHelperClass.getDeclaredMethod("getEncryptionKey", List.class);
+        method.setAccessible(true);
+        long key = (long) method.invoke(kMeansClusterHelper, taps);
+
+        assertEquals(4 * (long) StrictMath.pow(10, 10 + 0), key);
     }
 }

--- a/config/quality/findbugs/findbugs-filter.xml
+++ b/config/quality/findbugs/findbugs-filter.xml
@@ -48,4 +48,18 @@
         <Method name="generateKey" />
         <Bug pattern="ICAST_IDIV_CAST_TO_DOUBLE" />
     </Match>
+
+    <!-- Suppressed because we actually need this double because the division will be rounded off otherwise! -->
+    <Match>
+        <Class name="com.nervousfish.nervousfish.activities.RhythmVerificationActivity$KMeansClusterHelper" />
+        <Method name="addNumIntervalsToKey" />
+        <Bug pattern="ICAST_IDIV_CAST_TO_DOUBLE" />
+    </Match>
+
+    <!-- Suppressed because we need a long because we'll get a buffer overflow otherwise -->
+    <Match>
+        <Class name="com.nervousfish.nervousfish.activities.RhythmVerificationActivity$KMeansClusterHelper" />
+        <Method name="addNumIntervalsToKey" />
+        <Bug pattern="ICAST_INTEGER_MULTIPLY_CAST_TO_LONG" />
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
<!-- Check if the pull request title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
<!-- Specify what this pull request adds to the project -->
This Pull Request adds to the repository a mapping for intervals to Short when all intervals have approximately the same length (i.e. short / long > 0.75)

## Why
<!-- Specify why this issue is needed in the project -->
This Pull Request is needed because people sometimes tap a rhythm with all intervals approximately the same length

## How
<!-- Specify how this feature can be viewed or tested -->
This feature can be viewed/tested within the project by tapping a few intervals that are all even long and verifying that the encryption / decryption still works on both sides

## Alternative implementation
<!-- Specify any alternative implementations you have considered -->
Other implementations that I've have considered are ...

## Notes
<!-- Is there anything important reviewers should know? Do they need to take something into account while reviewing? -->
None
