### PR TITLE
Show an explanation in the rhythm / visual verification screen

### DIFF
--- a/app/src/main/res/layout/activity_rhythm_create.xml
+++ b/app/src/main/res/layout/activity_rhythm_create.xml
@@ -30,6 +30,15 @@
                 android:textStyle="bold" />
         </android.support.v7.widget.Toolbar>
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/select_verification_method_description_background_color"
+            android:padding="@dimen/select_verification_method_description_padding"
+            android:text="@string/rhythm_explanation"
+            android:textAlignment="center"
+            android:textColor="@color/white" />
+
         <include layout="@layout/content_rhythm_create" />
 
     </android.support.design.widget.AppBarLayout>

--- a/app/src/main/res/layout/activity_visual_verification.xml
+++ b/app/src/main/res/layout/activity_visual_verification.xml
@@ -2,12 +2,12 @@
 <android.support.percent.PercentRelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:baselineAligned="false"
     android:columnCount="4"
-    android:rowCount="4"
-    android:baselineAligned="false">
+    android:orientation="vertical"
+    android:rowCount="4">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -17,165 +17,181 @@
             android:id="@+id/image_view_visual_verification"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:src="@drawable/visualverification_farm"
             android:layout_alignParentBottom="true"
             android:layout_alignParentStart="true"
             android:scaleType="fitXY"
+            android:src="@drawable/visualverification_farm"
             tools:ignore="ContentDescription" /> <!-- Overlay doesn't need description, not relevant for people with bad eyesight -->
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/select_verification_method_description_background_color"
+            android:padding="@dimen/select_verification_method_description_padding"
+            android:text="@string/visual_verification_explanation"
+            android:textAlignment="center"
+            android:textColor="@color/white" />
     </RelativeLayout>
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/first_row"
-        android:orientation="horizontal"
         android:layout_width="match_parent"
+        android:orientation="horizontal"
         app:layout_heightPercent="25%">
 
         <Button
             android:id="@+id/visual_verification_button00"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="1"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
 
         <Button
             android:id="@+id/visual_verification_button01"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="2"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
+
         <Button
             android:id="@+id/visual_verification_button02"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="3"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
     </LinearLayout>
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/second_row"
-        android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_below="@id/first_row"
+        android:orientation="horizontal"
         app:layout_heightPercent="25%">
 
         <Button
             android:id="@+id/visual_verification_button10"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="4"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
+
         <Button
             android:id="@+id/visual_verification_button11"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="5"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
+
         <Button
             android:id="@+id/visual_verification_button12"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="6"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
     </LinearLayout>
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/third_row"
-        android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_below="@id/second_row"
+        android:orientation="horizontal"
         app:layout_heightPercent="25%">
 
         <Button
             android:id="@+id/visual_verification_button20"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="7"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
+
         <Button
             android:id="@+id/visual_verification_button21"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="8"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
+
         <Button
             android:id="@+id/visual_verification_button22"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="9"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
     </LinearLayout>
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_below="@id/third_row"
+        android:orientation="horizontal"
         app:layout_heightPercent="25%">
 
         <Button
             android:id="@+id/visual_verification_button30"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="10"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
+
         <Button
             android:id="@+id/visual_verification_button31"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="11"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
+
         <Button
             android:id="@+id/visual_verification_button32"
-            android:layout_height="match_parent"
+            style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
+            android:background="@drawable/visual_verification_button"
             android:contentDescription="12"
             android:onClick="buttonAction"
-            android:background="@drawable/visual_verification_button"
-            tools:ignore="HardcodedText"
-            style="?android:attr/buttonBarButtonStyle" />
+            tools:ignore="HardcodedText" />
     </LinearLayout>
 </android.support.percent.PercentRelativeLayout>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -42,6 +42,7 @@
     <string name="something_went_wrong">Er ging iets fout</string>
     <string name="try_again">Probeer opnieuw alstublieft.</string>
     <string name="waiting_for_partner">Wachten op partner…</string>
+    <string name="visual_verification_explanation">Druk 6 keer in dezelfde volgorde op objecten als je partner</string>
 
     <!-- Eerste gebruik -->
     <string name="welcome_title">Welkom bij NervousFish</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -88,6 +88,7 @@
     <string name="start_recording">Start met opnemen</string>
     <string name="too_few_taps_title">Te weinig getikt</string>
     <string name="too_few_taps_description">Je moet minimaal 3 keer tikken</string>
+    <string name="rhythm_explanation">Druk op \"Start met opnemen\" en tik hetzelfde ritme als je partner</string>
 
     <!-- Contacten -->
     <string name="contact_already_deleted">Dit contactpersoon was al eerder verwijderd</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="not_the_same_rhythm_explanation">The rhythm you tapped was not the same as on the other device.</string>
     <string name="not_the_same_visual_title">Tapping order was the same</string>
     <string name="not_the_same_visual_explanation">Make sure that the locations tapped and the order are the same on both devices.</string>
+    <string name="rhythm_explanation">Press \"Start recording\" and tap the same rhythm as your partner</string>
 
     <!-- Select verification method -->
     <string name="select_verification_method">How do you want to secure your connection?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="something_went_wrong">Something went wrong</string>
     <string name="try_again">Please try again.</string>
     <string name="waiting_for_partner">Waiting for partner…</string>
+    <string name="visual_verification_explanation">Tap 6 times in the same order on objects as your partner</string>
 
     <!-- First time use -->
     <string name="welcome_title">Welcome to NervousFish</string>


### PR DESCRIPTION
<!-- Check if the pull request title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
<!-- Specify what this pull request adds to the project -->
This Pull Request adds to the repository an explanation in the RhythmCreateActivity and VisualVerificationActivity

## Why
<!-- Specify why this issue is needed in the project -->
This Pull Request is needed because it was not clear at all for a test audience what they had to do in the rhythm and visual verification activity.

## How
<!-- Specify how this feature can be viewed or tested -->
This feature can be viewed/tested within the project by ...

## Alternative implementation
<!-- Specify any alternative implementations you have considered -->
Other implementations that I've have considered are ...

## Notes
<!-- Is there anything important reviewers should know? Do they need to take something into account while reviewing? -->
The available space to tap is now a little bit smaller in visual verification activity. If this is really a problem, then we should move the image below the explanation text.