### PR TITLE
Add noHistory to Bluetooth progress activities

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".activities.VisualVerificationActivity"
+            android:noHistory="true"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".activities.WaitActivity"
@@ -48,6 +49,7 @@
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".activities.RhythmVerificationActivity"
+            android:noHistory="true"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".activities.BluetoothConnectActivity"
@@ -69,7 +71,8 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
-        <activity android:name=".activities.SelectVerificationMethodActivity" />
+        <activity android:name=".activities.SelectVerificationMethodActivity"
+            android:noHistory="true" />
         <activity
             android:name=".activities.QRExchangeActivity"
             android:theme="@style/AppTheme.NoActionBar" />


### PR DESCRIPTION
<!-- Check if the pull request title is descriptive! -->
- Relevant Issues: -
- Related Pull Requests: -

* * *

## What
<!-- Specify what this pull request adds to the project -->
This Pull Request adds to the repository that the activities in the Bluetooth have no history.

## Why
<!-- Specify why this issue is needed in the project -->
This Pull Request is needed because it makes the Bluetooth progress a bit smoother when pressing the back button, however it does not yet fully cancel the connection.

## How
<!-- Specify how this feature can be viewed or tested -->
This feature can be viewed/tested within the project by making a connection over Bluetooth and pressing the back button.

## Alternative implementation
<!-- Specify any alternative implementations you have considered -->
None considered

## Notes
<!-- Is there anything important reviewers should know? Do they need to take something into account while reviewing? -->
None
